### PR TITLE
Tag command to search for people by tags

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -373,7 +373,7 @@ You provide a unique field. In this example the `John Doe` contact you will be e
 
 === Allow user to edit contact if duplicate contact is added
 
-Warns you about adding a contact that has the same name and same phone number or email or address field.
+Warns user about adding a contact that has the same name and same phone number or email or address field.
 Address Book allows you to add contact with the same name as an existing contact as long as one of the other fields
 are different.
 
@@ -381,24 +381,28 @@ Examples:
 
 * `add n/John Doe p/91234567 e/johndoe@example.com a/John street, block 123, #01-01` +
 `add n/John Doe p/98765432 e/differentemail@example.com a/Different street, block 123, #01-01` +
-Address Book will warn you that an existing contact John Doe already exists. Address Book will ask you if you would like
-to go ahead and create a new contact, edit the existing contact, or cancel the operation.
+Address Book will warn user that an existing contact John Doe already exists. Address Book will ask you if you would
+like to go ahead and create a new contact, edit the existing contact, or cancel the operation.
 
 === Using tags: `tag`
 
 ==== View contacts by tag
 View all contacts in any existing tag. +
-Format: `tag TAG_NAME`
+Format: `tag TAG_NAME [MORE_TAG_NAMES]`
+
+Shorthand: `t`
 
 ****
-* You can view all users that belong to the same tag.
+* View all contacts that belong to the same tag.
 * Address book will throw an error if an invalid `TAG_NAME` is given.
 ****
 
 Example:
 
 * `tag Work` +
-You can view all contacts with the `Work` tag.
+Returns all contacts with the `Work` tag.
+* `tag Work Important` +
+Returns all contacts with the `Work` or `Important` tags.
 
 ==== Remove a tag
 Remove all users from a tag. +

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,5 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_TAGGED_PERSONS_LISTED_OVERVIEW = "%1$d tagged persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.tag.PersonContainsTagPredicate;
+
+/**
+ * Finds and lists all persons in address book whose tag matches the argument keyword.
+ * Keyword matching is case insensitive.
+ */
+public class TagCommand extends Command {
+
+    public static final String COMMAND_WORD = "tag";
+    public static final String COMMAND_ALIAS = "t";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": View all contacts with a specified (case-sensitive) tag."
+            + "Parameters: TAG [MORE TAGS]...\n"
+            + "Example: " + COMMAND_WORD + " Work Friends Important";
+
+    private final PersonContainsTagPredicate predicate;
+
+    public TagCommand(PersonContainsTagPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_TAGGED_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagCommand // instanceof handles nulls
+                && predicate.equals(((TagCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -95,6 +96,10 @@ public class AddressBookParser {
         case RedoCommand.COMMAND_WORD:
         case RedoCommand.COMMAND_ALIAS:
             return new RedoCommand();
+
+        case TagCommand.COMMAND_WORD:
+        case TagCommand.COMMAND_ALIAS:
+            return new TagCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.TagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.PersonContainsTagPredicate;
+
+/**
+ * Parses input arguments and creates a new TagCommand object
+ */
+public class TagCommandParser implements Parser<TagCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the TagCommand
+     * and returns a TagCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public TagCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
+        }
+
+        String[] tagKeywords = trimmedArgs.split("\\s+");
+
+        return new TagCommand(new PersonContainsTagPredicate(Arrays.asList(tagKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/model/tag/PersonContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/tag/PersonContainsTagPredicate.java
@@ -1,0 +1,34 @@
+package seedu.address.model.tag;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person} contains any of the tags given.
+ */
+public class PersonContainsTagPredicate implements Predicate<Person> {
+    private final List<String> tags;
+
+    public PersonContainsTagPredicate(List<String> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return tags.stream()
+                .anyMatch(tagName -> {
+                    Tag tag = new Tag(tagName);
+                    return person.getTags().contains(tag);
+                });
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PersonContainsTagPredicate // instanceof handles nulls
+                && tags.equals(((PersonContainsTagPredicate) other).tags)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -1,0 +1,82 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_TAGGED_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.PersonContainsTagPredicate;
+
+public class TagCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void equals() {
+        PersonContainsTagPredicate firstPredicate =
+                new PersonContainsTagPredicate(Collections.singletonList("first"));
+        PersonContainsTagPredicate secondPredicate =
+                new PersonContainsTagPredicate(Collections.singletonList("second"));
+
+        TagCommand findFirstCommand = new TagCommand(firstPredicate);
+        TagCommand findSecondCommand = new TagCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        TagCommand findFirstCommandCopy = new TagCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different tag -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_TAGGED_PERSONS_LISTED_OVERVIEW, 0);
+        PersonContainsTagPredicate predicate = preparePredicate(" ");
+        TagCommand command = new TagCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_TAGGED_PERSONS_LISTED_OVERVIEW, 3);
+        PersonContainsTagPredicate predicate = preparePredicate("friends owesMoney");
+        TagCommand command = new TagCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code PersonContainsTagPredicate}.
+     */
+    private PersonContainsTagPredicate preparePredicate(String userInput) {
+        return new PersonContainsTagPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -26,10 +26,12 @@ import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.PersonContainsTagPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -120,7 +122,7 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommandAlais_find() throws Exception {
+    public void parseCommandAlias_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_ALIAS + " " + keywords.stream().collect(Collectors.joining(" ")));
@@ -213,6 +215,22 @@ public class AddressBookParserTest {
     public void parseCommand_undoCommandAlias_returnsUndoCommand() throws Exception {
         assertTrue(parser.parseCommand(UndoCommand.COMMAND_ALIAS) instanceof UndoCommand);
         assertTrue(parser.parseCommand("u 3") instanceof UndoCommand);
+    }
+
+    @Test
+    public void parseCommandWord_tag() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "friends", "colleagues");
+        TagCommand command = (TagCommand) parser.parseCommand(
+                TagCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new TagCommand(new PersonContainsTagPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommandAlias_tag() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "friends", "colleagues");
+        TagCommand command = (TagCommand) parser.parseCommand(
+                TagCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new TagCommand(new PersonContainsTagPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -122,7 +122,7 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommandAlias_find() throws Exception {
+    public void parseCommandAlais_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_ALIAS + " " + keywords.stream().collect(Collectors.joining(" ")));

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.TagCommand;
+import seedu.address.model.tag.PersonContainsTagPredicate;
+
+public class TagCommandParserTest {
+
+    private TagCommandParser parser = new TagCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                TagCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsTagCommand() {
+        // no leading and trailing whitespaces
+        TagCommand expectedTagCommand =
+                new TagCommand(new PersonContainsTagPredicate(Arrays.asList("friends", "owesMoney")));
+        assertParseSuccess(parser, "friends owesMoney", expectedTagCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n friends \n \t owesMoney  \t", expectedTagCommand);
+    }
+
+}


### PR DESCRIPTION
```tag``` command with alias ```t``` added to addressbook.

User are able to use ```tag [TAG_NAME_1] [MORE_TAG_NAMES]``` or ```t [TAG_NAME_1] [MORE_TAG_NAMES]``` to search for all contacts matching any one of the user-specified ```TAG_NAME```.

Example: ```tag work important```
All users tagged with either ```work``` or ```important``` will be listed in the addressbook.