### PR TITLE
Fix bug where meeting get removed

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PictureCommand.java
@@ -58,7 +58,7 @@ public class PictureCommand extends Command {
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
-                personToEdit.getAddress(), personToEdit.getTags());
+                personToEdit.getAddress(), personToEdit.getTags(), personToEdit.getMeeting());
         editedPerson.setPicture(picture);
 
         model.updatePerson(personToEdit, editedPerson);


### PR DESCRIPTION
Bug: when user picture is edited and the user has scheduled meetings, the meeting data gets removed.